### PR TITLE
Rename sskeychain via pod update

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '6.0'
 
-pod 'SSKeychain', '~> 1.2.2'
+pod 'SAMKeychain', '~> 1.5.2'
 
 target 'VENTouchLockTests' do
   pod 'Specta', '~> 0.2.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
   - Expecta (0.3.1)
   - OCMock (2.2.4)
+  - SAMKeychain (1.5.2)
   - Specta (0.2.1)
-  - SSKeychain (1.2.2)
 
 DEPENDENCIES:
   - Expecta (~> 0.2)
   - OCMock (~> 2.2.2)
+  - SAMKeychain (~> 1.5.2)
   - Specta (~> 0.2.1)
-  - SSKeychain (~> 1.2.2)
 
 SPEC CHECKSUMS:
   Expecta: a354d4633409dd9fe8c4f5ff5130426adbe31628
   OCMock: a6a7dc0e3997fb9f35d99f72528698ebf60d64f2
+  SAMKeychain: 1865333198217411f35327e8da61b43de79b635b
   Specta: 15a276a6343867b426d5ed135d5aa4d04123a573
-  SSKeychain: 88767e903ee8d274ed380e364d96b7a101235286
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.39.0

--- a/VENTouchLock.podspec
+++ b/VENTouchLock.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/venmo/VENTouchLock.git', :tag => "v#{s.version}"}
   s.source_files = 'VENTouchLock/**/*.{h,m}'
   s.resources   = ["VENTouchLock/**/*.{xib}"]
-  s.dependency 'SSKeychain', '~> 1.0'
+  s.dependency 'SAMKeychain', '~> 1.5.2'
   s.frameworks = 'LocalAuthentication'
   s.platform     = :ios, '7.0'
   s.requires_arc = true

--- a/VENTouchLock/VENTouchLock.m
+++ b/VENTouchLock/VENTouchLock.m
@@ -1,6 +1,6 @@
 #import "VENTouchLock.h"
 
-#import <SSKeychain/SSKeychain.h>
+#import <SAMKeychain/SAMKeychain.h>
 #import <LocalAuthentication/LocalAuthentication.h>
 #import "UIViewController+VENTouchLock.h"
 
@@ -74,7 +74,7 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
 {
     NSString *service = self.keychainService;
     NSString *account = self.keychainAccount;
-    return [SSKeychain passwordForService:service account:account];
+    return [SAMKeychain passwordForService:service account:account];
 }
 
 - (BOOL)isPasscodeValid:(NSString *)passcode
@@ -86,7 +86,7 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
 {
     NSString *service = self.keychainService;
     NSString *account = self.keychainAccount;
-    [SSKeychain setPassword:passcode forService:service account:account];
+    [SAMKeychain setPassword:passcode forService:service account:account];
 }
 
 - (void)deletePasscode
@@ -97,7 +97,7 @@ static NSString *const VENTouchLockUserDefaultsKeyTouchIDActivated = @"VENTouchL
 
     NSString *service = self.keychainService;
     NSString *account = self.keychainAccount;
-    [SSKeychain deletePasswordForService:service account:account];
+    [SAMKeychain deletePasswordForService:service account:account];
 }
 
 


### PR DESCRIPTION
due to naming conflict intro'd in iOS 10 (https://github.com/soffes/SAMKeychain/issues/154)
